### PR TITLE
Fix safewalk flagging MultiActionsC on Grim when shift click in inventory

### DIFF
--- a/src/main/java/arsenic/module/impl/world/SafeWalk.java
+++ b/src/main/java/arsenic/module/impl/world/SafeWalk.java
@@ -63,6 +63,10 @@ public class SafeWalk extends Module {
     public final Listener<EventLiving> tickEvent = tickEvent -> {
         // Early exits
         Mode mode = shiftMode.getValue();
+        if (mc.currentScreen != null) {
+            mode.accept(false);
+            return;
+        }
         if (onlySPressed.getValue() && !mc.gameSettings.keyBindBack.isKeyDown()) {
             mode.accept(Keyboard.isKeyDown(mc.gameSettings.keyBindSneak.getKeyCode()));
             return;


### PR DESCRIPTION
The reason of the sneak forced in inventory:
```java
if (onlySPressed.getValue() && !mc.gameSettings.keyBindBack.isKeyDown()) {
    mode.accept(Keyboard.isKeyDown(mc.gameSettings.keyBindSneak.getKeyCode()));
    return;
}
```

so ```Mode.Shift.accept()``` does ```KeyBinding.setKeyBindState(sneak, true)```
which bypass natural game suppression when inventory is open, forcing the sneak even with inventory GUI on

I don't think the overwrite of shift is a problem, probably the team made it intentionally otherwise it would keep you sneaking even when the player is walking safe because you're still physically holding shift + S (JUST SAYING, I DID NOT ANALYZE THIS DEEP TO CONFIRM IT'S PURPOSE)

So I made a simple fix by adding a early condition at tick event similar to what Radar does at the EventRender2d