### PR TITLE
Minor fix: ESC while binding does not close GUI (SUGGESTION)

### DIFF
--- a/src/main/java/arsenic/gui/click/ClickGuiScreen.java
+++ b/src/main/java/arsenic/gui/click/ClickGuiScreen.java
@@ -248,7 +248,7 @@ public class ClickGuiScreen extends CustomGuiScreen {
     protected void keyTyped(char typedChar, int keyCode) throws IOException {
         arsenic.utils.java.SoundUtils.tick();
         if(alwaysKeyboardInput != null) {
-            alwaysKeyboardInput.recieveInput(keyCode);
+            if(alwaysKeyboardInput.recieveInput(keyCode)) return;
             if (alwaysKeyboardInput != null) return;
         }
         ((SearchComponent) searchComponent).recieveInput(keyCode);


### PR DESCRIPTION
Before: on one ESC click it unbound and close GUI at the same time
After: ESC while binding only unbound, ESC while not binding close GUI